### PR TITLE
Restructure datePickerDialog listener, moved to utils.

### DIFF
--- a/app/src/main/java/com/example/movies_mvvm/ui/add_movie/AddItemFragment.kt
+++ b/app/src/main/java/com/example/movies_mvvm/ui/add_movie/AddItemFragment.kt
@@ -18,15 +18,16 @@ import com.example.movies_mvvm.data.model.Item
 import com.example.movies_mvvm.databinding.AddItemLayoutBinding
 import com.example.movies_mvvm.ui.ItemsViewModel
 import utils.*
-import java.text.SimpleDateFormat
 import java.util.*
 
 class AddItemFragment : Fragment() {
 
     private var _binding: AddItemLayoutBinding? = null
     private val binding get() = _binding!!
-
     private var imageUri: Uri? = null
+    private var isDateSelected = false
+    private val calendar: Calendar = Calendar.getInstance()
+    private lateinit var datePickerDialog: DatePickerDialog
 
     private val viewModel: ItemsViewModel by activityViewModels()
 
@@ -51,33 +52,13 @@ class AddItemFragment : Fragment() {
             inflater, container, false
         )
 
-        var isDateSelected = false
-        val calendar = Calendar.getInstance()
-
-        val listener = DatePickerDialog.OnDateSetListener { _, year, month, day ->
-            calendar.apply {
-                set(Calendar.YEAR, year)
-                set(Calendar.MONTH, month)
-                set(Calendar.DAY_OF_MONTH, day)
-            }
-            val myFormat = "dd/MM/yyyy"
-            val sdf = SimpleDateFormat(myFormat, Locale.FRENCH)
-            binding.addMovieReleaseDate.apply {
-                setText(sdf.format(calendar.time))
-                isDateSelected = true
-                val isFuture = isFutureDate(text.toString())
-                binding.addMovieRating.apply {
-                    isEnabled = !isFuture
-                    setText(if (isFuture) "" else "0")
-                }
-                binding.addRatingContainer.helperText = when {
-                    isFuture -> "Rating is disabled, the movie isn't release yet!"
-                    else -> "Rating isn't required, default value is 0"
-                }
-            }
+        val listener = DatePickerDialog.OnDateSetListener { _, year, month, dayOfMonth ->
+            isDateSelected = true
+            calendar.set(year, month, dayOfMonth)
+            getDateSetListener(binding, calendar).onDateSet(null, year, month, dayOfMonth)
         }
 
-        val datePickerDialog = container?.let {
+        datePickerDialog = container?.let {
             DatePickerDialog(
                 it.context,
                 listener,
@@ -85,7 +66,7 @@ class AddItemFragment : Fragment() {
                 calendar.get(Calendar.MONTH),
                 calendar.get(Calendar.DAY_OF_MONTH)
             )
-        }
+        }!!
 
         titleFocusListener()
         descriptionFocusListener()

--- a/app/src/main/java/com/example/movies_mvvm/ui/edit_movie/EditItemFragment.kt
+++ b/app/src/main/java/com/example/movies_mvvm/ui/edit_movie/EditItemFragment.kt
@@ -19,21 +19,17 @@ import com.example.movies_mvvm.data.model.Item
 import com.example.movies_mvvm.databinding.EditItemLayoutBinding
 import com.example.movies_mvvm.ui.ItemsViewModel
 import utils.*
-import java.text.SimpleDateFormat
 import java.util.*
 
 class EditItemFragment : Fragment() {
 
     private var _binding: EditItemLayoutBinding? = null
     private val binding get() = _binding!!
-
     private var imageUri: Uri? = null
     private var initialImageUri: String? = null
-    private var isDateSelected = false
     private var movieId: Int? = null
-
+    private var isDateSelected = false
     private val calendar: Calendar = Calendar.getInstance()
-
     private lateinit var datePickerDialog: DatePickerDialog
 
     private val viewModel: ItemsViewModel by activityViewModels()
@@ -59,27 +55,10 @@ class EditItemFragment : Fragment() {
             inflater, container, false
         )
 
-        val listener = DatePickerDialog.OnDateSetListener { _, year, month, day ->
-            calendar.apply {
-                set(Calendar.YEAR, year)
-                set(Calendar.MONTH, month)
-                set(Calendar.DAY_OF_MONTH, day)
-            }
-            val myFormat = "dd/MM/yyyy"
-            val sdf = SimpleDateFormat(myFormat, Locale.FRENCH)
-            binding.addMovieReleaseDate.apply {
-                setText(sdf.format(calendar.time))
-                isDateSelected = true
-                val isFuture = isFutureDate(text.toString())
-                binding.addMovieRating.apply {
-                    isEnabled = !isFuture
-                    if (isFuture) setText("")
-                }
-                binding.addRatingContainer.helperText = when {
-                    isFuture -> "Rating is disabled, the movie isn't release yet!"
-                    else -> "Rating isn't required, default value is 0"
-                }
-            }
+        val listener = DatePickerDialog.OnDateSetListener { _, year, month, dayOfMonth ->
+            isDateSelected = true
+            calendar.set(year, month, dayOfMonth)
+            getDateSetListener(binding, calendar).onDateSet(null, year, month, dayOfMonth)
         }
 
         datePickerDialog = container?.let {

--- a/app/src/main/java/utils/utils.kt
+++ b/app/src/main/java/utils/utils.kt
@@ -1,5 +1,9 @@
 package utils
 
+import android.app.DatePickerDialog
+import androidx.viewbinding.ViewBinding
+import com.example.movies_mvvm.databinding.AddItemLayoutBinding
+import com.example.movies_mvvm.databinding.EditItemLayoutBinding
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -49,3 +53,45 @@ fun validRating(movieRating: String, isEnabled: Boolean, releaseDate: String): S
     }
     return null
 }
+
+fun getDateSetListener(
+    binding: ViewBinding,
+    calendar: Calendar
+): DatePickerDialog.OnDateSetListener {
+    return DatePickerDialog.OnDateSetListener { _, _, _, _ ->
+        val myFormat = "dd/MM/yyyy"
+        val sdf = SimpleDateFormat(myFormat, Locale.FRENCH)
+        val ratingContainerText = mapOf(
+            true to "Rating is disabled, the movie isn't release yet!",
+            false to "Rating isn't required, default value is 0"
+        )
+        when (binding) {
+            is AddItemLayoutBinding -> {
+                binding.addMovieReleaseDate.apply {
+                    setText(sdf.format(calendar.time))
+                    clearFocus()
+                    val isFuture = isFutureDate(text.toString())
+                    binding.addMovieRating.apply {
+                        isEnabled = !isFuture
+                        setText("0")
+                    }
+                    binding.addRatingContainer.helperText = ratingContainerText[isFuture]
+                }
+            }
+            is EditItemLayoutBinding -> {
+                binding.addMovieReleaseDate.apply {
+                    setText(sdf.format(calendar.time))
+                    clearFocus()
+                    val isFuture = isFutureDate(text.toString())
+                    binding.addMovieRating.apply {
+                        isEnabled = !isFuture
+                        if (isFuture || text.toString().isEmpty()) setText("0")
+                    }
+                    binding.addRatingContainer.helperText = ratingContainerText[isFuture]
+                }
+            }
+        }
+    }
+}
+
+


### PR DESCRIPTION
Restructure the date picker dialog listener, and move to utils since we had duplicate code in AddItem and EditItem.